### PR TITLE
Revamp onboarding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,15 @@ EveNet is a multi-task, event-level neural network for large-scale high-energy p
 
 ## 🚀 Quickstart Workflow
 
-1. **Install dependencies.**
+1. **Start from the prebuilt Docker image (recommended).** Pull the GPU-enabled container so CUDA, PyTorch, and system libraries are preconfigured.
    ```bash
-   pip install -r requirements.txt
+   docker pull docker.io/avencast1994/evenet:1.3
+   docker run --gpus all -it \
+     -v /path/to/your/data:/workspace/data \
+     -v $(pwd):/workspace/project \
+     docker.io/avencast1994/evenet:1.3
    ```
+   Inside the container, change to `/workspace/project` to access this checkout. If you cannot use Docker, install dependencies manually with `pip install -r requirements.txt`.
 2. **Prepare your dataset.** Follow the [data guide](docs/data_preparation.md#run-the-preprocessing-cli) to configure preprocessing for your ntuples, then build parquet shards and normalization stats.
 3. **Launch training.** Edit the example YAML (see the [configuration reference](docs/configuration.md)) and run:
    ```bash

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ EveNet is a multi-task, event-level neural network for large-scale high-energy p
 ---
 
 ## 🧭 Quick Navigation
-- 👉 [Data preparation & input guide](docs/data_preparation.md)
+- 📘 [New user tutorial](docs/getting_started.md)
+- 🧪 [Data preparation & input guide](docs/data_preparation.md)
 - ⚙️ [Configuration reference](docs/configuration.md)
 - 🧠 [Model architecture tour](docs/model_architecture.md)
 
@@ -13,15 +14,21 @@ EveNet is a multi-task, event-level neural network for large-scale high-energy p
 
 ## 🚀 Quickstart Workflow
 
-| Step | Action | Command / Notes |
-| --- | --- | --- |
-| 1️⃣ | Install dependencies | ```bash
-pip install -r requirements.txt
-``` |
-| 2️⃣ | Prepare your dataset | Follow the [data guide](docs/data_preparation.md#run-the-preprocessing-cli) to configure preprocessing for your ntuples, then build parquet shards + normalization stats. |
-| 3️⃣ | Launch training | Tweak the example YAML (see the [configuration reference](docs/configuration.md)) and run:<br>`WANDB_API_KEY=<your_key> \`<br>`python evenet/train.py share/finetune-example.yaml` |
-| 4️⃣ | Run prediction | Point the prediction YAML at your checkpoint and execute:<br>`python evenet/predict.py share/predict-example.yaml` |
-| 5️⃣ | Explore results | Visualize metrics in Weights & Biases or the local log directory listed in the YAML. |
+1. **Install dependencies.**
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. **Prepare your dataset.** Follow the [data guide](docs/data_preparation.md#run-the-preprocessing-cli) to configure preprocessing for your ntuples, then build parquet shards and normalization stats.
+3. **Launch training.** Edit the example YAML (see the [configuration reference](docs/configuration.md)) and run:
+   ```bash
+   WANDB_API_KEY=<your_key> \
+   python evenet/train.py share/finetune-example.yaml
+   ```
+4. **Run prediction.** Point the prediction YAML at your checkpoint and execute:
+   ```bash
+   python evenet/predict.py share/predict-example.yaml
+   ```
+5. **Explore results.** Visualize metrics in Weights & Biases or the local log directory listed in the YAML.
 
 > 💡 **Tip:** Ray launches one worker per GPU/CPU pair by default. Adjust `platform.number_of_workers` and `platform.resources_per_worker` inside the YAML to scale up or down.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,8 @@ Welcome to the EveNet control center! This document explains how the YAML exampl
 
 ---
 
-## 🧰 Loader Basics {#loader-basics}
+<a id="loader-basics"></a>
+## 🧰 Loader Basics
 
 Top-level scripts expect a single YAML path as their **positional** argument:
 
@@ -32,7 +33,8 @@ Inside the script, `evenet/control/global_config.py` handles parsing:
 
 ---
 
-## 📄 Tour of `share/finetune-example.yaml` {#finetune-example}
+<a id="finetune-example"></a>
+## 📄 Tour of `share/finetune-example.yaml`
 
 This example highlights the main sections you will encounter:
 
@@ -67,7 +69,8 @@ For inference, `share/predict-example.yaml` mirrors the structure but requires `
 
 ---
 
-## 🧩 Options Deep Dive {#options-deep-dive}
+<a id="options-deep-dive"></a>
+## 🧩 Options Deep Dive
 
 `share/options/options.yaml` collects optimizer groups, scheduler defaults, and component toggles. Use the top-level `options` block in your example file to override any field.
 
@@ -107,7 +110,8 @@ Within `options.Training` you will find:
 
 ---
 
-## 🏗️ Network Templates {#network-templates}
+<a id="network-templates"></a>
+## 🏗️ Network Templates
 
 Files under `share/network/` specify architectural hyperparameters for the shared body and task heads. For example, [`share/network/network-20M.yaml`](../share/network/network-20M.yaml) defines transformer depth, attention heads, neighborhood sizes, and diffusion dimensions. Override specific fields inside the `network` section of your top-level YAML to experiment without editing the base template.
 
@@ -115,7 +119,8 @@ Files under `share/network/` specify architectural hyperparameters for the share
 
 ---
 
-## 🧬 Physics Metadata {#physics-metadata}
+<a id="physics-metadata"></a>
+## 🧬 Physics Metadata
 
 ### Event Info
 
@@ -142,13 +147,15 @@ Templates under [`share/resonance/`](../share/resonance) hold reusable resonance
 
 ---
 
-## 📦 Prediction Extras {#prediction-notes}
+<a id="prediction-notes"></a>
+## 📦 Prediction Extras
 
 `share/predict-example.yaml` includes an `options.prediction` block where you can specify the output directory, filename, and any extra tensors to persist. The `platform` section mirrors training but is often tuned for throughput (e.g., more workers with smaller batch sizes). Always set `Training.model_checkpoint_load_path` to the checkpoint you want to score.
 
 ---
 
-## 🆕 Creating a New Experiment {#new-experiment}
+<a id="new-experiment"></a>
+## 🆕 Creating a New Experiment
 
 1. **Copy an example** – duplicate `share/finetune-example.yaml` (or `share/predict-example.yaml`).
 2. **Update paths** – fill in `platform.data_parquet_dir`, `options.Dataset.normalization_file`, and logging/checkpoint directories.

--- a/docs/data_preparation.md
+++ b/docs/data_preparation.md
@@ -10,7 +10,8 @@ Welcome! This guide shows how to convert raw ntuples into EveNet-ready parquet s
 
 ---
 
-## 🔭 Pipeline Overview {#pipeline-overview}
+<a id="pipeline-overview"></a>
+## 🔭 Pipeline Overview
 
 1. **Draft a config** – start from your own YAML (you can peek at the internal `share/preprocess_pretrain.yaml` for inspiration) and list the processes, selections, and padding choices you need.
 2. **Customize selections** – edit aliases, anchors, and selection blocks to match the processes you want to keep.
@@ -21,7 +22,8 @@ Welcome! This guide shows how to convert raw ntuples into EveNet-ready parquet s
 
 ---
 
-## ⚙️ Run the Preprocessing CLI {#run-the-preprocessing-cli}
+<a id="run-the-preprocessing-cli"></a>
+## ⚙️ Run the Preprocessing CLI
 
 ```bash
 python preprocessing/preprocess.py share/preprocess_pretrain.yaml \
@@ -60,7 +62,8 @@ Peek at the in-repo reference (`share/preprocess_pretrain.yaml`) when you need m
 
 ---
 
-## 📁 Outputs & Artifact Map {#outputs-artifact-map}
+<a id="outputs-artifact-map"></a>
+## 📁 Outputs & Artifact Map
 
 Running the pipeline fills `--store_dir` with a tidy bundle:
 
@@ -75,7 +78,8 @@ Running the pipeline fills `--store_dir` with a tidy bundle:
 
 ---
 
-## 🧬 Dataset Layout {#dataset-layout}
+<a id="dataset-layout"></a>
+## 🧬 Dataset Layout
 
 Each parquet row is a single event. Shapes below reference the **unflattened** tensors reconstructed with `shape_metadata.json`.
 
@@ -107,7 +111,8 @@ Each parquet row is a single event. Shapes below reference the **unflattened** t
 
 ---
 
-## 📚 Reading Datasets in EveNet {#reading-datasets}
+<a id="reading-datasets"></a>
+## 📚 Reading Datasets in EveNet
 
 When you run training or prediction, `evenet/shared.py` stitches everything back together:
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,97 @@
+# 📘 EveNet Tutorial: From Zero to First Predictions
+
+New to EveNet? This tutorial walks you through the end-to-end workflow so you can move from a clean checkout to model predictions with confidence. Each step links to a deeper reference guide if you need more detail.
+
+---
+
+## 1. Understand the Project Layout
+
+Before running any commands, skim these key directories:
+
+- `evenet/` – PyTorch Lightning modules, Ray data pipelines, and trainer utilities.
+- `preprocessing/` – CLI and helpers for converting raw ntuples into parquet shards and metadata.
+- `share/` – Ready-to-edit YAML configurations for preprocessing, training, and prediction.
+- `docs/` – Reference documentation that expands on this tutorial.
+
+---
+
+## 2. Set Up Your Environment
+
+1. **Install Python dependencies.** EveNet targets Python 3.10+.
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. **Optional:** If you plan to run inside Docker or on NERSC, review the environment helpers under `Docker/` and `NERSC/` for prebuilt container recipes and SLURM launch scripts.
+3. **Verify GPU visibility (if available).**
+   ```bash
+   python -c "import torch; print(torch.cuda.device_count())"
+   ```
+
+---
+
+## 3. Prepare Input Data
+
+1. **Start from a preprocessing YAML.** Duplicate `share/preprocess_pretrain.yaml` (or another example) and customize:
+   - Campaign directories (`pretrain_dirs` or `in_dir`)
+   - Process lists, selections, and padding strategy
+   - Output paths (`store_dir`)
+2. **Run the preprocessing CLI.**
+   ```bash
+   python preprocessing/preprocess.py share/preprocess_pretrain.yaml \
+     --pretrain_dirs /path/to/run_A /path/to/run_B \
+     --store_dir /path/to/output \
+     --cpu_max 32
+   ```
+3. **Inspect outputs.** The command produces `data_*.parquet`, `shape_metadata.json`, and `normalization.pt` artifacts described in the [data preparation guide](data_preparation.md).
+
+> 🔍 Tip: Keep preprocessing configs in version control to document how each dataset was produced.
+
+---
+
+## 4. Configure an Experiment
+
+1. Copy `share/finetune-example.yaml` (for training) and `share/predict-example.yaml` (for inference) into a working directory.
+2. Update paths and experiment metadata:
+   - `platform.data_parquet_dir` → location of your processed parquet files
+   - `Dataset.normalization_file` → normalization statistics file from preprocessing
+   - `logger` → project names, WANDB API key, or local log paths
+3. Review the [configuration reference](configuration.md) for a description of every YAML section and available overrides.
+
+---
+
+## 5. Train the Model
+
+1. Export your Weights & Biases API key if you plan to log online.
+   ```bash
+   export WANDB_API_KEY=<your_key>
+   ```
+2. Launch training with your updated YAML.
+   ```bash
+   python evenet/train.py path/to/your-train-config.yaml
+   ```
+3. Monitor progress:
+   - Console output provides per-epoch metrics and checkpoint locations.
+   - WANDB dashboards (if enabled) visualize loss curves and system stats.
+   - Checkpoints and logs are stored under `options.Training.model_checkpoint_save_path`.
+4. Consult `docs/train.md` for details on checkpointing, EMA weights, and resume logic.
+
+---
+
+## 6. Generate Predictions
+
+1. Ensure the prediction YAML points to the trained checkpoint via `options.Training.model_checkpoint_load_path`.
+2. Launch inference.
+   ```bash
+   python evenet/predict.py path/to/your-predict-config.yaml
+   ```
+3. Outputs land in the configured writers (e.g., parquet, numpy archives). See `docs/predict.md` for writer options and schema notes.
+
+---
+
+## 7. Explore and Iterate
+
+- Use the artifacts written in the prediction step for downstream analysis (examples live under `downstreams/`).
+- Adjust YAML hyperparameters, architecture templates, or preprocessing selections and repeat the workflow.
+- When adding new datasets or modules, contribute documentation updates so the next user can follow your path.
+
+Happy exploring! 🚀

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -17,11 +17,16 @@ Before running any commands, skim these key directories:
 
 ## 2. Set Up Your Environment
 
-1. **Install Python dependencies.** EveNet targets Python 3.10+.
+1. **Pull the official Docker image (recommended).** It bundles CUDA, PyTorch, and all Python requirements so you can start immediately.
    ```bash
-   pip install -r requirements.txt
+   docker pull docker.io/avencast1994/evenet:1.3
+   docker run --gpus all -it \
+     -v /path/to/your/data:/workspace/data \
+     -v $(pwd):/workspace/project \
+     docker.io/avencast1994/evenet:1.3
    ```
-2. **Optional:** If you plan to run inside Docker or on NERSC, review the environment helpers under `Docker/` and `NERSC/` for prebuilt container recipes and SLURM launch scripts.
+   Inside the container, switch to `/workspace/project` to use your local checkout. If Docker is unavailable, install dependencies manually with `pip install -r requirements.txt` on Python 3.10+.
+2. **Review cluster helpers as needed.** The `Docker/` and `NERSC/` directories include recipes and SLURM launch scripts tailored for HPC environments.
 3. **Verify GPU visibility (if available).**
    ```bash
    python -c "import torch; print(torch.cuda.device_count())"

--- a/docs/model_architecture.md
+++ b/docs/model_architecture.md
@@ -11,7 +11,8 @@ Take a guided walk through EveNet’s multitask architecture—from input normal
 
 ---
 
-## 🔁 Signal Flow at a Glance {#signal-flow}
+<a id="signal-flow"></a>
+## 🔁 Signal Flow at a Glance
 
 ```mermaid
 flowchart LR
@@ -67,7 +68,8 @@ Every stage is instantiated inside [`evenet/network/evenet_model.py`](../evenet/
 
 ---
 
-## 🧴 Input Normalization {#input-normalization}
+<a id="input-normalization"></a>
+## 🧴 Input Normalization
 
 When `EveNetModel` is built, it grabs feature statistics from `normalization.pt` plus schema details from `event_info` and constructs a collection of `Normalizer` layers:
 
@@ -80,7 +82,8 @@ Implementation details live near the top of [`evenet/network/evenet_model.py`](.
 
 ---
 
-## 🧱 Shared Body {#shared-body}
+<a id="shared-body"></a>
+## 🧱 Shared Body
 
 ### 🌐 Global Embedding
 `GlobalVectorEmbedding` converts the condition vector into learned tokens. Hyperparameters like depth, hidden dimension, dropout, and activation come from the `Body.GlobalEmbedding` block described in the [configuration reference](configuration.md#network-templates).
@@ -93,7 +96,8 @@ Outputs from the PET body and global tokens meet in the `ObjectEncoder`, which m
 
 ---
 
-## 🎯 Task Heads {#task-heads}
+<a id="task-heads"></a>
+## 🎯 Task Heads
 
 Heads are instantiated only when `options.Training.Components.<Head>.include` is `true`.
 
@@ -121,13 +125,15 @@ EveNet carries **three** diffusion-based heads, all orchestrated in the forward 
 
 ---
 
-## 🌀 Progressive Training Hooks {#progressive-training}
+<a id="progressive-training"></a>
+## 🌀 Progressive Training Hooks
 
 `EveNetModel` exposes `schedule_flags` describing which heads are active (diffusion, neutrino, deterministic). The training loop combines these flags with the curriculum defined in `options.ProgressiveTraining` so that loss weights, dropout, or EMA decay ramp smoothly over time. Inspect the scheduling logic in [`evenet/network/evenet_model.py`](../evenet/network/evenet_model.py#L352-L380) and pair it with the YAML stages summarized in the [configuration reference](configuration.md#options-deep-dive).
 
 ---
 
-## 🛠️ Customizing the Network {#customizing}
+<a id="customizing"></a>
+## 🛠️ Customizing the Network
 
 1. **Pick a template** – choose a network block described in the [configuration reference](configuration.md#network-templates) and copy it into your experiment YAML.
 2. **Override selectively** – in your top-level YAML, override only the fields you want to tweak (e.g., set `Body.PET.feature_drop: 0.0` for fine-tuning).


### PR DESCRIPTION
## Summary
- add a beginner-friendly tutorial that walks through preprocessing, configuration, training, and prediction
- rework the README quickstart section to fix markdown formatting and highlight the tutorial
- replace non-functional `{#...}` anchors in existing docs with GitHub-compatible IDs for reliable deep-linking

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68df78b52db88331b79b8dea7b700dbb